### PR TITLE
Add Unit of work

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -28,11 +28,14 @@
 
 
     <ItemGroup>
-      <Folder Include="Features\Group\Commands\CreateGroup\" />
       <Folder Include="Features\Group\Commands\UpdateGroup\" />
       <Folder Include="Features\Group\Queries\GetAllGroups\" />
       <Folder Include="Features\Group\Queries\GetOneGroup\" />
-      <Folder Include="Features\Location\" />
+      <Folder Include="Features\Location\Commands\CreateLocation\" />
+      <Folder Include="Features\Location\Commands\UpdateLocation\" />
+      <Folder Include="Features\Location\Queries\GetAllLocations\" />
+      <Folder Include="Features\Location\Queries\GetLocationById\" />
+      <Folder Include="Features\Location\Queries\GetLocationByName\" />
     </ItemGroup>
   
     <ItemGroup>

--- a/Application/Contracts/Persistence/IA2SVGroupRepository.cs
+++ b/Application/Contracts/Persistence/IA2SVGroupRepository.cs
@@ -1,0 +1,9 @@
+﻿using Application.Contracts.Persistence.Common;
+using Domain.Entities;
+
+namespace Application.Contracts.Persistence;
+
+public interface IA2SVGroupRepository : IGenericRepository<GroupEntity>
+{
+    
+}

--- a/Application/Contracts/Persistence/ILocationRepository.cs
+++ b/Application/Contracts/Persistence/ILocationRepository.cs
@@ -1,0 +1,9 @@
+﻿using Application.Contracts.Persistence.Common;
+using Domain.Entities;
+
+namespace Application.Contracts.Persistence;
+
+public interface ILocationRepository : IGenericRepository<LocationEntity>
+{
+    
+}

--- a/Application/Contracts/Persistence/ITeamRepository.cs
+++ b/Application/Contracts/Persistence/ITeamRepository.cs
@@ -1,0 +1,9 @@
+﻿using Application.Contracts.Persistence.Common;
+using Domain.Entities;
+
+namespace Application.Contracts.Persistence;
+
+public interface ITeamRepository : IGenericRepository<TeamEntity>
+{
+    
+}

--- a/Application/Contracts/Persistence/IUnitOfWork.cs
+++ b/Application/Contracts/Persistence/IUnitOfWork.cs
@@ -1,0 +1,11 @@
+﻿namespace Application.Contracts.Persistence;
+
+public interface IUnitOfWork
+{
+    IUserRepository UserRepository { get; }
+    IUserTypeRepository UserTypeRepository { get; }
+    ITeamRepository TeamRepository { get; }
+    IContestRepository ContestRepository { get; }
+    ILocationRepository LocationRepository { get; }
+    IA2SVGroupRepository A2SVGroupRepository { get; }
+}

--- a/Application/Contracts/Persistence/IUserTypeRepository.cs
+++ b/Application/Contracts/Persistence/IUserTypeRepository.cs
@@ -1,0 +1,9 @@
+﻿using Application.Contracts.Persistence.Common;
+using Domain.Entities;
+
+namespace Application.Contracts.Persistence;
+
+public interface IUserTypeRepository : IGenericRepository<UserTypeEntity>
+{
+    
+}

--- a/Application/Features/Group/Commands/CreateGroup/CreateGroupCommand.cs
+++ b/Application/Features/Group/Commands/CreateGroup/CreateGroupCommand.cs
@@ -1,0 +1,9 @@
+﻿using Application.DTOs.Group;
+using MediatR;
+
+namespace Application.Features.Group.Commands.CreateGroup;
+
+public class CreateGroupCommand : IRequest<GroupResponseDto>
+{
+    public GroupRequestDto GroupRequestDto { get; set; } = null!;
+}

--- a/Application/Features/Group/Commands/CreateGroup/CreateGroupCommandHandler.cs
+++ b/Application/Features/Group/Commands/CreateGroup/CreateGroupCommandHandler.cs
@@ -1,0 +1,12 @@
+﻿using Application.DTOs.Group;
+using MediatR;
+
+namespace Application.Features.Group.Commands.CreateGroup;
+
+public class CreateGroupCommandHandler : IRequestHandler<CreateGroupCommand, GroupResponseDto>
+{
+    public Task<GroupResponseDto> Handle(CreateGroupCommand request, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Persistence/Repositories/A2SVGroupRepository.cs
+++ b/Persistence/Repositories/A2SVGroupRepository.cs
@@ -1,0 +1,12 @@
+﻿using Application.Contracts.Persistence;
+using Domain.Entities;
+using Persistence.Repositories.Common;
+
+namespace Persistence.Repositories;
+
+public class A2SVGroupRepository : GenericRepository<GroupEntity>, IA2SVGroupRepository
+{
+    protected A2SVGroupRepository(AppDBContext dbContext) : base(dbContext)
+    {
+    }
+}

--- a/Persistence/Repositories/LocationRepository.cs
+++ b/Persistence/Repositories/LocationRepository.cs
@@ -1,0 +1,12 @@
+﻿using Application.Contracts.Persistence;
+using Domain.Entities;
+using Persistence.Repositories.Common;
+
+namespace Persistence.Repositories;
+
+public class LocationRepository : GenericRepository<LocationEntity>, ILocationRepository
+{
+    protected LocationRepository(AppDBContext dbContext) : base(dbContext)
+    {
+    }
+}

--- a/Persistence/Repositories/UnitOfWork.cs
+++ b/Persistence/Repositories/UnitOfWork.cs
@@ -1,0 +1,25 @@
+﻿using Application.Contracts.Persistence;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Persistence.Repositories;
+
+public class UnitOfWork : IUnitOfWork
+{
+
+    public IUserRepository UserRepository { get; }
+    public IUserTypeRepository UserTypeRepository { get; }
+    public ITeamRepository TeamRepository { get; }
+    public IContestRepository ContestRepository { get; }
+    public ILocationRepository LocationRepository { get; }
+    public IA2SVGroupRepository A2SVGroupRepository { get; }
+    
+    public UnitOfWork(IUserRepository userRepository, IUserTypeRepository userTypeRepository, ITeamRepository teamRepository, IContestRepository contestRepository, ILocationRepository locationRepository, IA2SVGroupRepository a2SvGroupRepository)
+    {
+        UserRepository = userRepository;
+        UserTypeRepository = userTypeRepository;
+        TeamRepository = teamRepository;
+        ContestRepository = contestRepository;
+        LocationRepository = locationRepository;
+        A2SVGroupRepository = a2SvGroupRepository;
+    }
+}


### PR DESCRIPTION
For the convenience of injecting more than one repository within the application layer for handlers, I added unit of work centralized access to repositories. Use this Unit of work to access any repository you want.